### PR TITLE
fix(create): name the path and the occupant on a worktree collision

### DIFF
--- a/commands/create.sh
+++ b/commands/create.sh
@@ -246,8 +246,19 @@ _cmd_create_core() {
     fi
 
     # Check if worktree already exists
+    #
+    # The bare "already exists" this used to print reads as stale state, and a session that
+    # reads it that way writes into a checkout somebody else is standing in. Naming the path
+    # and the occupant turns it into what it is: a collision with another seat.
     if worktree_exists "$branch" "$repo_root"; then
-        die "Worktree already exists for branch: $branch"
+        local existing_path occupant
+        existing_path=$(worktree_path "$branch" "$repo_root")
+        occupant=$(worktree_occupant "$existing_path")
+
+        if [[ -n "$occupant" ]]; then
+            die "Worktree for '$branch' already exists at $existing_path, held by cmux workspace '$occupant'. Tell them before writing there, or join with: wt open $branch"
+        fi
+        die "Worktree for '$branch' already exists at $existing_path (nobody sitting in it). Join with: wt open $branch"
     fi
 
     # Run pre_create hook if defined

--- a/lib/worktree.sh
+++ b/lib/worktree.sh
@@ -75,6 +75,27 @@ worktree_path() {
     echo "$candidate"
 }
 
+# Name the cmux workspace standing in a worktree, when one is.
+# A worktree nobody sits in reads as free to every session that arrives later, including one
+# picking up the same branch — so a collision has to say who is already there, not just that
+# the directory exists. Degrades to silence rather than failing: cmux and jq are how this
+# machine answers the question, not a dependency of the CLI.
+# Args: $1 worktree path
+# Out: a human-readable workspace label, or nothing when unoccupied or unanswerable
+worktree_occupant() {
+    local path="$1"
+
+    [[ -n "$path" ]] || return 0
+    command -v cmux &>/dev/null || return 0
+    command -v jq &>/dev/null || return 0
+
+    cmux workspace list --json 2>/dev/null | jq -r --arg p "$path" '
+        .workspaces[]?
+        | select(.current_directory == $p or (.current_directory | startswith($p + "/")))
+        | if (.has_custom_title // false) then .custom_title else (.id | .[0:8]) end
+    ' 2>/dev/null | head -1
+}
+
 # Check if a worktree exists for a branch
 worktree_exists() {
     local branch="$1"

--- a/tests/test_worktree.bats
+++ b/tests/test_worktree.bats
@@ -186,3 +186,82 @@ teardown() {
     run prune_worktrees "$TEST_REPO"
     [[ "$status" -eq 0 ]]
 }
+
+# --- worktree_occupant ---
+
+# The collision message is what a parallel session reads before deciding whether it may write
+# into a checkout. It degrades rather than fails: a machine without cmux still gets the path.
+
+@test "worktree_occupant is silent when cmux is unavailable" {
+    PATH="/usr/bin:/bin" run worktree_occupant "/some/worktree"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "worktree_occupant is silent for an empty path" {
+    run worktree_occupant ""
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "worktree_occupant names the workspace whose cwd is the worktree" {
+    local fake="$TEST_TMPDIR/bin"
+    mkdir -p "$fake"
+    cat > "$fake/cmux" <<'CMUX'
+#!/usr/bin/env bash
+cat <<'JSON'
+{"workspaces":[{"current_directory":"/w/feature","has_custom_title":true,"custom_title":"seat-a","id":"AAAA1111-x"}]}
+JSON
+CMUX
+    chmod +x "$fake/cmux"
+
+    PATH="$fake:$PATH" run worktree_occupant "/w/feature"
+    [ "$status" -eq 0 ]
+    [ "$output" = "seat-a" ]
+}
+
+@test "worktree_occupant matches a workspace sitting in a subdirectory" {
+    local fake="$TEST_TMPDIR/bin"
+    mkdir -p "$fake"
+    cat > "$fake/cmux" <<'CMUX'
+#!/usr/bin/env bash
+cat <<'JSON'
+{"workspaces":[{"current_directory":"/w/feature/src/deep","has_custom_title":true,"custom_title":"seat-b","id":"BBBB2222-x"}]}
+JSON
+CMUX
+    chmod +x "$fake/cmux"
+
+    PATH="$fake:$PATH" run worktree_occupant "/w/feature"
+    [ "$output" = "seat-b" ]
+}
+
+@test "worktree_occupant falls back to a short id when the workspace is untitled" {
+    local fake="$TEST_TMPDIR/bin"
+    mkdir -p "$fake"
+    cat > "$fake/cmux" <<'CMUX'
+#!/usr/bin/env bash
+cat <<'JSON'
+{"workspaces":[{"current_directory":"/w/feature","has_custom_title":false,"custom_title":null,"id":"CCCC3333-dddd"}]}
+JSON
+CMUX
+    chmod +x "$fake/cmux"
+
+    PATH="$fake:$PATH" run worktree_occupant "/w/feature"
+    [ "$output" = "CCCC3333" ]
+}
+
+# The half that proves it discriminates: a neighbouring path is not a match.
+@test "worktree_occupant does not match a sibling worktree by prefix" {
+    local fake="$TEST_TMPDIR/bin"
+    mkdir -p "$fake"
+    cat > "$fake/cmux" <<'CMUX'
+#!/usr/bin/env bash
+cat <<'JSON'
+{"workspaces":[{"current_directory":"/w/feature-two","has_custom_title":true,"custom_title":"seat-c","id":"DDDD4444-x"}]}
+JSON
+CMUX
+    chmod +x "$fake/cmux"
+
+    PATH="$fake:$PATH" run worktree_occupant "/w/feature"
+    [ -z "$output" ]
+}


### PR DESCRIPTION
## Why

`wt create` on an existing worktree died with:

```
[ERROR] Worktree already exists for branch: <branch>
```

That reads as **stale state**, not as another seat. A session that reads it that way writes into a checkout somebody is standing in.

It happened today. A parallel session ran `wt create` on a worktree I was already working in, took the error for leftover state, and wrote whole-file into `shared/utils/*.test.ts` — clobbering 20 uncommitted test cases. They were untracked, so there was nothing to recover from. The reading was the natural one; nothing in the message suggested a live occupant.

## What changes

Only what the error prints. The check still fires in the same place and still exits non-zero.

```
Worktree for 'x' already exists at /path, held by cmux workspace 'seat-a'.
Tell them before writing there, or join with: wt open x

Worktree for 'x' already exists at /path (nobody sitting in it).
Join with: wt open x
```

`worktree_occupant` (`lib/worktree.sh`) answers the second half by matching a cmux workspace's `current_directory` against the worktree path.

**It degrades rather than fails.** No cmux, no jq, or no answer → silence, and the caller still gets the path. cmux and jq are how *this* machine answers the question; they are not a dependency of the CLI, and a machine without them must not get a broken `wt create`.

## Tests

6 cases in `tests/test_worktree.bats`, including the two that keep it honest:

- **silent when cmux is unavailable** — run under `PATH=/usr/bin:/bin`, so the degradation path is pinned rather than assumed
- **no match on a sibling path** — `/w/feature-two` is not a match for `/w/feature`, which a naive `startswith` would get wrong

Plus: exact-path match, subdirectory match (a session cd'd deeper still counts as occupying), untitled-workspace fallback to a short id, and empty-path guard.

## Suite

```
before: 313 tests, exit 0
after:  319 tests, exit 0
```

Baseline run before the change, per `CLAUDE.md` — a suite already red beforehand would have made a clean edit look like a regression.

Verified on a real collision, not only under the fake:

```
$ wt create chore/untrack-embed-bundles
[ERROR] Worktree for 'chore/untrack-embed-bundles' already exists at
        /Users/yannlauwers/worktrees/les-gites-du-haras/chore-untrack-embed-bundles
        (nobody sitting in it). Join with: wt open chore/untrack-embed-bundles
```

## Note on the docs contract

`CLAUDE.md` requires regenerating `COMMANDS.md` via `scripts/gen-docs.sh` after adding a function, enforced by `tests/test_docs.bats`. None of the three exists in this checkout — `docs/` holds only `configuration.md`. The new function carries its doc-comment per the convention, but there is nothing to regenerate. Flagging rather than fixing: that clause is either describing a pipeline that was removed, or one that has yet to land.

## Compatibility

bash 3.2 clean — no namerefs, no associative arrays, no GNU-only constructs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)