### PR TITLE
ci: run the suite on macOS as well as Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,15 +7,28 @@ on:
 
 jobs:
   tests:
-    name: bats suite
-    runs-on: ubuntu-latest
+    name: bats suite (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      # Both platforms report. Cancelling the sibling on the first failure would
+      # hide exactly the asymmetry this matrix exists to surface.
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
-      - name: Install dependencies
+
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y bats tmux
           sudo curl -fsSL -o /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
           sudo chmod +x /usr/local/bin/yq
+
+      - name: Install dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: brew install bats-core yq tmux
+
       - name: Run tests
         run: bats tests/


### PR DESCRIPTION
Closes the gap flagged when CI landed in #3.

## Why

The workflow ran `ubuntu-latest` alone, while `wt` is developed on macOS. That covers one direction of drift and not the other.

The covered direction has already paid for itself. `create_worktree` asked the working directory for its branch instead of the repository it was given — every local macOS run passed, and the **first** Linux run failed fourteen tests. The reverse case (green on Linux, broken on the machine the tool is actually used from) is caught by nobody today.

## What it adds

```yaml
strategy:
  fail-fast: false
  matrix:
    os: [ubuntu-latest, macos-latest]
```

**`fail-fast: false` is deliberate.** Cancelling the sibling job on the first failure would hide exactly the asymmetry this matrix exists to surface — when the two platforms disagree, *both* answers are the finding, not just the first one to arrive.

Dependencies split per runner:

| Runner | Install |
|---|---|
| Linux | `apt-get install bats tmux` + the `yq_linux_amd64` binary — unchanged from #3 |
| macOS | `brew install bats-core yq tmux` |

## A second thing macOS buys

`CONTRIBUTING.md` lists bash 3.2 compatibility among what gets reviewed — "no namerefs, no GNU-only constructs". Nothing enforced it: Ubuntu runners ship bash 5.

macOS runners ship 3.2 as `/bin/bash`, so a nameref or a GNU-only construct now fails in CI instead of on a user's machine. That check was written down as a review criterion and had no mechanism behind it.

## What this PR measures about itself

The suite passes locally on macOS — but a runner is not a developer's machine, and *that* assumption is precisely what let the last bug through. Whether it is green on `macos-latest` is what this PR's own run answers.

If macOS goes red, that is a real finding about the suite or the tool, and the fix belongs there — not in weakening the matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)