### PR TITLE
fix(delete): resolve branch_exists against the repo root, not the cwd

### DIFF
--- a/commands/delete.sh
+++ b/commands/delete.sh
@@ -152,7 +152,7 @@ cmd_delete() {
     local branch_deleted=0
     if [[ "$keep_branch" == "1" ]]; then
         log_info "Branch kept: $branch"
-    elif ! branch_exists "$branch"; then
+    elif ! branch_exists "$branch" "$repo_root"; then
         branch_deleted=1
     fi
 

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -117,16 +117,21 @@ current_branch() {
 }
 
 # Check if a branch exists locally
+# Args: $1 branch, $2 repo root (optional; defaults to the caller's cwd, which is wrong
+#       whenever the caller stands outside the repo or inside a worktree being removed)
 branch_exists() {
     local branch="$1"
-    git show-ref --verify --quiet "refs/heads/$branch"
+    local repo_root="${2:-.}"
+    git -C "$repo_root" show-ref --verify --quiet "refs/heads/$branch"
 }
 
 # Check if a branch exists on remote
+# Args: $1 branch, $2 remote (default origin), $3 repo root (optional; defaults to cwd)
 remote_branch_exists() {
     local branch="$1"
     local remote="${2:-origin}"
-    git ls-remote --exit-code --heads "$remote" "$branch" &>/dev/null
+    local repo_root="${3:-.}"
+    git -C "$repo_root" ls-remote --exit-code --heads "$remote" "$branch" &>/dev/null
 }
 
 # Confirm action with user

--- a/lib/worktree.sh
+++ b/lib/worktree.sh
@@ -176,7 +176,7 @@ create_worktree() {
     local git_exit_code
 
     # Check if branch already exists
-    if branch_exists "$branch"; then
+    if branch_exists "$branch" "$repo_root"; then
         log_info "Branch '$branch' exists, creating worktree..." >&2
         git_output=$(git -C "$repo_root" worktree add "$wt_path" "$branch" 2>&1)
         git_exit_code=$?
@@ -188,7 +188,7 @@ create_worktree() {
             git_exit_code=$?
         else
             # Check if remote branch exists
-            if remote_branch_exists "$branch"; then
+            if remote_branch_exists "$branch" origin "$repo_root"; then
                 log_info "Tracking remote branch '$branch'..." >&2
                 git_output=$(git -C "$repo_root" worktree add --track -b "$branch" "$wt_path" "origin/$branch" 2>&1)
                 git_exit_code=$?
@@ -277,9 +277,10 @@ remove_worktree() {
         log_warn "Worktree force-removed after retry: $wt_path"
     fi
 
-    # Optionally delete the branch
+    # Optionally delete the branch. Resolve against the repo, never the cwd: `wt delete`
+    # runs from outside the repo, or from inside the worktree that was just removed.
     if [[ "$keep_branch" == "0" ]]; then
-        if branch_exists "$branch"; then
+        if branch_exists "$branch" "$repo_root"; then
             log_info "Deleting branch: $branch"
             if [[ "$force" == "1" ]]; then
                 git -C "$repo_root" branch -D "$branch" 2>/dev/null || true

--- a/tests/test_zz_delete_safety.bats
+++ b/tests/test_zz_delete_safety.bats
@@ -146,6 +146,33 @@ _commit_in() {
     ! git -C "$TEST_REPO" show-ref --verify --quiet "refs/heads/feat/unmerged-force"  # -D dropped it
 }
 
+@test "remove_worktree deletes the branch when invoked from outside the repo" {
+    local wt_path
+    wt_path=$(create_worktree "feat/from-outside" "" "$TEST_REPO" 2>/dev/null)
+    # Branch tip == main: clean and merged, so -d deletes it wherever git is asked from.
+
+    # The cwd is NOT a git repo. Before the fix, branch_exists ran `git show-ref` here,
+    # failed with "not a git repository", and the branch survived while the caller
+    # reported it deleted.
+    cd "$TEST_TMPDIR"
+    remove_worktree "feat/from-outside" 0 0 "$TEST_REPO" >/dev/null 2>&1
+
+    ! worktree_exists "feat/from-outside" "$TEST_REPO"
+    ! git -C "$TEST_REPO" show-ref --verify --quiet "refs/heads/feat/from-outside"  # branch gone
+}
+
+@test "cmd_delete reports the branch deleted only when it is gone, from outside the repo" {
+    _write_config "outside"
+    local wt_path
+    wt_path=$(create_worktree "feat/outside-cmd" "" "$TEST_REPO" 2>/dev/null)
+
+    cd "$TEST_TMPDIR"
+    run cmd_delete "feat/outside-cmd" -f -p outside
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"branch deleted"* ]]
+    ! git -C "$TEST_REPO" show-ref --verify --quiet "refs/heads/feat/outside-cmd"
+}
+
 # ── SHARP EDGE: the bulk (picker/prune) path is force-by-default ──────────────
 
 @test "SHARP EDGE: _delete_batch force-deletes a dirty worktree — no guard on the bulk path" {


### PR DESCRIPTION
## Why

`wt delete <branch>` run from outside the repo, or from inside the worktree it has just removed, printed "Worktree and branch deleted" while the local branch survived. The two `git show-ref` calls behind `branch_exists` ran in the caller's cwd and failed with "not a git repository", so the branch-deletion step was skipped and the success line printed anyway.

## What

- `branch_exists` and `remote_branch_exists` take a repo root and run `git -C` against it, defaulting to the cwd for callers that pass none.
- Every call site in `create_worktree`, `remove_worktree` and `cmd_delete` passes the repo root it already holds.
- Two tests in `tests/test_zz_delete_safety.bats` pin the from-outside path: `remove_worktree` deletes a merged branch when invoked from a non-repo cwd, and `cmd_delete` reports the branch deleted only once it is gone.

## How to test

1. `bats tests/test_zz_delete_safety.bats` (9 tests, the two new ones included).
2. `bats tests/` for the whole suite (323 tests).
3. Live: from a directory that is not a git repo, `wt delete <merged-branch> --force -p <project>`, then `git -C <repo> branch --list <merged-branch>` is empty.

## Reviewer notes

The existing "keeps an unmerged branch" test carried a comment recording the old assumption ("branch_exists checks CWD's repo, as wt delete runs from inside the repo"); the new tests are the counter-case.