### PR TITLE
docs(agents): record the repo's git model

### DIFF
--- a/docs/agents/integrations/git.md
+++ b/docs/agents/integrations/git.md
@@ -1,0 +1,20 @@
+---
+tool: git
+role: vcs
+defaults:
+  pr_draft: false
+  merge_actor: agent
+---
+# Git defaults — wt
+
+<role>Deltas from the `git` floor (`~/.agents/docs/integrations/git.md`) for this repo. Keys absent here keep the floor's values.</role>
+
+<context>
+Single-author repository: the pull request stores the change and gives CI its run on both platforms, and the author is the only reviewer. A PR therefore opens ready and the run merges it itself once the machine loop is clean. `base_branch` stays `auto`, which derives `main`.
+</context>
+
+## Commit scopes
+
+<context>
+Common scopes in this repo (illustrative, not an allowlist): `delete`, `create`, `ci`. Refresh from the log: `git log --oneline -200 --pretty=%s | grep -oE '\(([a-z0-9/-]+)\)' | sort | uniq -c | sort -rn`.
+</context>


### PR DESCRIPTION
## Why

The git skill fell back to its user-level defaults here (draft PRs, merge after approval) because the repo had no project config, so a fix landed as a draft and waited for a hand that a single-author repo does not need.

## What

- `docs/agents/integrations/git.md` records the two deltas from the floor: `pr_draft: false` and `merge_actor: agent`.
- Base branch stays derived (`main`); commit scopes listed as a snapshot.

## How to test

1. `~/.agents/bin/agents-config resolve git` from this directory lists the project layer as present.
2. The next PR opened by a session here opens ready and merges itself once CI is green.